### PR TITLE
fix broken links

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_3429
+++ b/integration/dockerfiles/Dockerfile_test_issue_3429
@@ -1,0 +1,13 @@
+FROM ubuntu
+
+RUN mkdir /test \
+    && ln -s /test /link
+
+# Fails on main@1d2bff5 before #3429: On the second run,
+# when extracting from cache, we first delete the /test directory
+# and thereafter fail to replace the link with a directory.
+# The link is now broken and 'stat' returns an error.
+# On build this works as we first delete the link,
+# and only thereafter create the directory.
+RUN rm -rf /test /link \
+    && mkdir /link

--- a/integration/images.go
+++ b/integration/images.go
@@ -218,6 +218,7 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 		"Dockerfile_test_cache_install": {},
 		"Dockerfile_test_cache_perm":    {},
 		"Dockerfile_test_cache_copy":    {},
+		"Dockerfile_test_issue_3429":    {},
 	}
 	d.TestOCICacheDockerfiles = map[string]struct{}{
 		"Dockerfile_test_cache_oci":         {},

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -843,7 +843,7 @@ func Volumes() []string {
 
 func MkdirAllWithPermissions(path string, mode os.FileMode, uid, gid int64) error {
 	// Check if a file already exists on the path, if yes then delete it
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err == nil && !info.IsDir() {
 		logrus.Tracef("Removing file because it needs to be a directory %s", path)
 		if err := os.Remove(path); err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

see https://github.com/GoogleContainerTools/kaniko/pull/3429
Fixes https://github.com/GoogleContainerTools/kaniko/issues/3428 https://github.com/GoogleContainerTools/kaniko/issues/3442

**Description**

Upon cache extraction, in case there is a broken symlink, both stat and mkdir will fail, resulting in cache extraction to fail.
Use lstat instead to not follow the broken symlink.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
