### PR TITLE
Add support for --annotation flags during build

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -54,6 +54,9 @@ jobs:
           persist-credentials: false
 
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        with:
+          driver: docker-container
+          driver-opts: network=host # Allows buildx to access the local registry.
 
       - run: make install-container-diff k3s-setup
       - run: make ${{ matrix.make-target }}

--- a/README.md
+++ b/README.md
@@ -925,6 +925,13 @@ times for multiple registries.
 Set this flag as `--label key=value` to set some metadata to the final image.
 This is equivalent as using the `LABEL` within the Dockerfile.
 
+#### Flag `--annotation`
+
+Set this flag as `--annotation key=value` to set some metadata to the final image.
+[Annotation levels](https://docs.docker.com/build/metadata/annotations/#specify-annotation-level) 
+are currently not supported and it's always the manifest that's 
+annotated.
+
 #### Flag `--log-format`
 
 Set this flag as `--log-format=<text|color|json>` to set the log format.

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -280,6 +280,8 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().VarP(&opts.IgnorePaths, "ignore-path", "", "Ignore these paths when taking a snapshot. Set it repeatedly for multiple paths.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.ForceBuildMetadata, "force-build-metadata", "", false, "Force add metadata layers to build image")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipPushPermissionCheck, "skip-push-permission-check", "", false, "Skip check of the push permission")
+	opts.Annotations = make(map[string]string)
+	RootCmd.PersistentFlags().VarP(&opts.Annotations, "annotation", "", "Set metadata annotations for the image in key=value format. Set it repeatedly for multiple annotations.")
 
 	// Deprecated flags.
 	RootCmd.PersistentFlags().StringVarP(&opts.SnapshotModeDeprecated, "snapshotMode", "", "", "This flag is deprecated. Please use '--snapshot-mode'.")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -55,6 +55,7 @@ type KanikoOptions struct {
 	Destinations             multiArg
 	BuildArgs                multiArg
 	Labels                   multiArg
+	Annotations              keyValueArg
 	Git                      KanikoGitOptions
 	IgnorePaths              multiArg
 	DockerfilePath           string

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -786,6 +786,9 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 					return nil, err
 				}
 			}
+			if len(opts.Annotations) > 0 {
+				sourceImage = mutate.Annotations(sourceImage, opts.Annotations).(v1.Image)
+			}
 			if opts.Cleanup {
 				if err = util.DeleteFilesystem(); err != nil {
 					return nil, err


### PR DESCRIPTION
This adds barebones support for annotating the manifests of the images built with kaniko. Note that annotation-levels as supported by Docker are currently not supported.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- kaniko adds a new flag `--annotation` to add annotations to the image manifest

```
