### PR TITLE
Switch container-diff for diffoci

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -55,5 +55,5 @@ jobs:
 
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - run: make install-container-diff k3s-setup
+      - run: make install-diffoci k3s-setup
       - run: make ${{ matrix.make-target }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,7 +49,7 @@ Images built with kaniko should be no different from images built elsewhere.
 While you iterate on kaniko, you can verify images built with kaniko by:
 
 1. Build the image using another system, such as `docker build`
-2. Use [`container-diff`](https://github.com/GoogleContainerTools/container-diff) to diff the images
+2. Use [`diffoci`](https://github.com/mzihlmann/diffoci) to diff the images
 
 ## Testing kaniko
 
@@ -90,7 +90,7 @@ These tests will be kicked off by [reviewers](#reviews) for submitted PRs using 
 
 In either case, you will need the following tools:
 
-* [`container-diff`](https://github.com/GoogleContainerTools/container-diff#installation)
+* [`diffoci`](https://github.com/mzihlmann/diffoci#installation)
 
 #### GCloud
 

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,12 @@ out/executor: $(GO_FILES)
 out/warmer: $(GO_FILES)
 	GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o $@ $(WARMER_PACKAGE)
 
-.PHONY: install-container-diff
-install-container-diff:
-	@ curl -LO https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-$(GOOS)-amd64 && \
-		chmod +x container-diff-$(GOOS)-amd64 && sudo mv container-diff-$(GOOS)-amd64 /usr/local/bin/container-diff
+.PHONY: install-diffoci
+install-diffoci:
+	@ git clone https://github.com/mzihlmann/diffoci.git && \
+		cd diffoci/cmd/diffoci && \
+		go mod vendor && \
+		go install
 
 .PHONY: k3s-setup
 k3s-setup:

--- a/integration/dockerfiles/Dockerfile_test_issue_1039
+++ b/integration/dockerfiles/Dockerfile_test_issue_1039
@@ -7,4 +7,5 @@ RUN yum --disableplugin=subscription-manager update -y \
         gcc-4.8.5-39.el7 \
         gcc-c++-4.8.5-39.el7 \
         make-3.82-24.el7 \
-    && yum --disableplugin=subscription-manager clean all
+    && yum --disableplugin=subscription-manager clean all \
+    && rm -rf /var/cache/yum /var/lib/yum/yumdb

--- a/integration/dockerfiles/Dockerfile_test_issue_1837
+++ b/integration/dockerfiles/Dockerfile_test_issue_1837
@@ -1,6 +1,9 @@
 FROM registry.access.redhat.com/ubi8/ubi:8.2 AS base
 # Install ping
-RUN yum --disableplugin=subscription-manager install -y iputils
+RUN dnf install -y iputils \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf /var/log/dnf* /var/log/rhsm
+
 RUN setcap cap_net_raw+ep /bin/ping || exit 1
 
 FROM base

--- a/integration/dockerfiles/Dockerfile_test_issue_2066
+++ b/integration/dockerfiles/Dockerfile_test_issue_2066
@@ -1,8 +1,15 @@
 FROM ubuntu:focal as base
-RUN apt update
-RUN apt install -y libbsd0
+
+RUN apt-get update \
+    && apt-get install -y libbsd0 \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN apt remove -y libbsd0
-RUN apt install -y libbsd0
+
+RUN apt-get update \
+    && apt-get install -y libbsd0 \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN ls -al /usr/lib/x86_64-linux-gnu/libbsd.so.0
 
 FROM base as b

--- a/integration/dockerfiles/Dockerfile_test_issue_684
+++ b/integration/dockerfiles/Dockerfile_test_issue_684
@@ -1,4 +1,7 @@
 # ubuntu:bionic-20200219
 FROM ubuntu@sha256:04d48df82c938587820d7b6006f5071dbbffceb7ca01d2814f81857c631d44df as builder
 
-RUN apt-get update && apt-get -y upgrade && apt-get -y install lib32stdc++6 wget
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y install lib32stdc++6 wget \
+    && rm -rf /var/lib/apt/lists/*

--- a/integration/images.go
+++ b/integration/images.go
@@ -69,8 +69,9 @@ var argsMap = map[string][]string{
 
 // Environment to build Dockerfiles with, used for both docker and kaniko builds
 var envsMap = map[string][]string{
-	"Dockerfile_test_arg_secret":    {"SSH_PRIVATE_KEY=ThEPriv4t3Key"},
-	"Dockerfile_test_copyadd_chmod": {"DOCKER_BUILDKIT=1"},
+	"Dockerfile_test_arg_secret":                 {"SSH_PRIVATE_KEY=ThEPriv4t3Key"},
+	"Dockerfile_test_copyadd_chmod":              {"DOCKER_BUILDKIT=1"},
+	"Dockerfile_test_multistage_args_issue_1911": {"DOCKER_BUILDKIT=1"},
 }
 
 // Arguments to build Dockerfiles with when building with docker
@@ -87,6 +88,19 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_maintainer":             {"--single-snapshot"},
 	"Dockerfile_test_target":                 {"--target=second"},
 	"Dockerfile_test_snapshotter_ignorelist": {"--use-new-run=true", "-v=trace"},
+}
+
+// Arguments to diffoci when comparing dockerfiles
+var diffArgsMap = map[string][]string{
+	// /root/.config 0x1c0 0x1ed
+	// I suspect the issue is that /root/.config pre-exists,
+	// it's where we store the docker credentials.
+	"TestWithContext/test_with_context_issue-1020": {"--extra-ignore-files=root/.config/"},
+	// docker is wrong. we do copy the symlink correctly.
+	"TestRun/test_Dockerfile_test_copy_symlink": {"--extra-ignore-files=workdirAnother/relative_link"},
+	"TestRun/test_Dockerfile_test_multistage":   {"--extra-ignore-files=new"},
+	// docker is wrong. we set permissions to 777 as instructed, they set to 755
+	"TestRun/test_Dockerfile_test_copyadd_chmod": {"--extra-ignore-files=dir777/"},
 }
 
 // output check to do when building with kaniko

--- a/integration/images.go
+++ b/integration/images.go
@@ -101,6 +101,13 @@ var diffArgsMap = map[string][]string{
 	"TestRun/test_Dockerfile_test_multistage":   {"--extra-ignore-files=new"},
 	// docker is wrong. we set permissions to 777 as instructed, they set to 755
 	"TestRun/test_Dockerfile_test_copyadd_chmod": {"--extra-ignore-files=dir777/"},
+	// WORKDIR is not cached https://github.com/GoogleContainerTools/kaniko/issues/3340
+	"TestCache/test_cache_Dockerfile_test_cache_install":         {"--semantic"},
+	"TestCache/test_oci_cache_Dockerfile_test_cache_install_oci": {"--semantic"},
+	// empty RUN statements are treated differently whether they are built from scratch or from cache
+	// https://github.com/GoogleContainerTools/kaniko/pull/3496
+	"TestCache/test_cache_Dockerfile_test_cache":         {"--semantic", "--extra-ignore-layer-length-mismatch"},
+	"TestCache/test_oci_cache_Dockerfile_test_cache_oci": {"--semantic", "--extra-ignore-layer-length-mismatch"},
 }
 
 // output check to do when building with kaniko

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -53,7 +53,7 @@ var (
 )
 
 const (
-	daemonPrefix       = "daemon://"
+	daemonPrefix       = "docker://"
 	integrationPath    = "integration"
 	dockerfilesPath    = "dockerfiles"
 	emptyContainerDiff = `[
@@ -204,10 +204,7 @@ func TestRun(t *testing.T) {
 			dockerImage := GetDockerImage(config.imageRepo, dockerfile)
 			kanikoImage := GetKanikoImage(config.imageRepo, dockerfile)
 
-			diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
-
-			expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
-			checkContainerDiffOutput(t, diff, expected)
+			containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-permissions", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
 		})
 	}
 
@@ -280,10 +277,7 @@ func testGitBuildcontextHelper(t *testing.T, repo string) {
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 
-	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
-
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
-	checkContainerDiffOutput(t, diff, expected)
+	containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-permissions", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
 }
 
 // TestGitBuildcontext explicitly names the main branch
@@ -352,10 +346,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 
-	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
-
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
-	checkContainerDiffOutput(t, diff, expected)
+	containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-permissions", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
 }
 
 func TestBuildViaRegistryMirrors(t *testing.T) {
@@ -394,10 +385,7 @@ func TestBuildViaRegistryMirrors(t *testing.T) {
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 
-	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
-
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
-	checkContainerDiffOutput(t, diff, expected)
+	containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-permissions", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
 }
 
 func TestBuildViaRegistryMap(t *testing.T) {
@@ -436,10 +424,7 @@ func TestBuildViaRegistryMap(t *testing.T) {
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 
-	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
-
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
-	checkContainerDiffOutput(t, diff, expected)
+	containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-permissions", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
 }
 
 func TestBuildSkipFallback(t *testing.T) {
@@ -501,10 +486,7 @@ func TestKanikoDir(t *testing.T) {
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 
-	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
-
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
-	checkContainerDiffOutput(t, diff, expected)
+	containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-permissions", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
 }
 
 func TestBuildWithLabels(t *testing.T) {
@@ -546,10 +528,7 @@ func TestBuildWithLabels(t *testing.T) {
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 
-	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
-
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
-	checkContainerDiffOutput(t, diff, expected)
+	containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-permissions", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
 }
 
 func TestBuildWithHTTPError(t *testing.T) {
@@ -589,9 +568,12 @@ func TestBuildWithHTTPError(t *testing.T) {
 }
 
 func TestLayers(t *testing.T) {
+	// offset is caused because for those two files we use
+	// --single-snapshot option, compressing all layers into one
 	offset := map[string]int{
-		"Dockerfile_test_add":     12,
-		"Dockerfile_test_scratch": 3,
+		"Dockerfile_test_add":        12,
+		"Dockerfile_test_scratch":    3,
+		"Dockerfile_test_maintainer": 0,
 	}
 
 	if os.Getenv("CI") == "true" {
@@ -738,10 +720,7 @@ func verifyBuildWith(t *testing.T, cache, dockerfile string) {
 	kanikoVersion0 := GetVersionedKanikoImage(config.imageRepo, dockerfile, 0)
 	kanikoVersion1 := GetVersionedKanikoImage(config.imageRepo, dockerfile, 1)
 
-	diff := containerDiff(t, kanikoVersion0, kanikoVersion1)
-
-	expected := fmt.Sprintf(emptyContainerDiff, kanikoVersion0, kanikoVersion1, kanikoVersion0, kanikoVersion1)
-	checkContainerDiffOutput(t, diff, expected)
+	containerDiff(t, kanikoVersion0, kanikoVersion1)
 }
 
 func TestRelativePaths(t *testing.T) {
@@ -767,10 +746,7 @@ func TestRelativePaths(t *testing.T) {
 		dockerImage := GetDockerImage(config.imageRepo, "test_relative_"+dockerfile)
 		kanikoImage := GetKanikoImage(config.imageRepo, "test_relative_"+dockerfile)
 
-		diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
-
-		expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
-		checkContainerDiffOutput(t, diff, expected)
+		containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-permissions", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
 	})
 }
 
@@ -1115,7 +1091,7 @@ func initIntegrationTestConfig() *integrationTestConfig {
 }
 
 func meetsRequirements() bool {
-	requiredTools := []string{"container-diff"}
+	requiredTools := []string{"diffoci"}
 	hasRequirements := true
 	for _, tool := range requiredTools {
 		_, err := exec.LookPath(tool)
@@ -1145,10 +1121,10 @@ func containerDiff(t *testing.T, image1, image2 string, flags ...string) []byte 
 	}
 
 	flags = append([]string{"diff"}, flags...)
-	flags = append(flags, image1, image2,
-		"-q", "--type=file", "--type=metadata", "--json")
+	flags = append(flags, image1, image2, "--ignore-image-name", "--ignore-image-timestamps")
+	flags = append(flags, diffArgsMap[t.Name()]...)
 
-	containerdiffCmd := exec.Command("container-diff", flags...)
+	containerdiffCmd := exec.Command("diffoci", flags...)
 	diff := RunCommand(containerdiffCmd, t)
 	t.Logf("diff = %s", string(diff))
 

--- a/integration/integration_with_context_test.go
+++ b/integration/integration_with_context_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package integration
 
 import (
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -64,11 +63,7 @@ func TestWithContext(t *testing.T) {
 			dockerImage := GetDockerImage(config.imageRepo, name)
 			kanikoImage := GetKanikoImage(config.imageRepo, name)
 
-			diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
-
-			expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
-			checkContainerDiffOutput(t, diff, expected)
-
+			containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-permissions", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
 		})
 	}
 

--- a/integration/integration_with_stdin_test.go
+++ b/integration/integration_with_stdin_test.go
@@ -140,10 +140,7 @@ func TestBuildWithStdin(t *testing.T) {
 		t.Fatalf("can't wait %s: %v", kanikoCmdStdin.String(), err)
 	}
 
-	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImageStdin, "--no-cache")
-
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImageStdin, dockerImage, kanikoImageStdin)
-	checkContainerDiffOutput(t, diff, expected)
+	containerDiff(t, daemonPrefix+dockerImage, kanikoImageStdin, "--semantic", "--extra-ignore-file-permissions", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
 
 	if err := os.RemoveAll(testDirLongPath); err != nil {
 		t.Errorf("Failed to remove %s: %v", testDirLongPath, err)

--- a/integration/k8s_test.go
+++ b/integration/k8s_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package integration
 
 import (
-	"fmt"
 	"io/fs"
 	"log"
 	"os"
@@ -130,10 +129,7 @@ func TestK8s(t *testing.T) {
 				t.Fatal(errR)
 			}
 
-			diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
-
-			expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
-			checkContainerDiffOutput(t, diff, expected)
+			containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-permissions", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
 		})
 	}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

our integration-tests use container-diff to compare the build output of docker and kaniko. But container-diff has a lot of drawbacks. The way container-diff works under-the-hood as far as I understand, is it untars the docker images and then diffs the two directories. It also only compares certain files and it only compares their size, not their content. This is fine to check whether we are missing files completely, but in the untarring process we lose all file metadata. That is less important for timestamps, but way way more important for file-mode and file-permissions, which we currently still struggle with as seen in https://github.com/chainguard-dev/kaniko/pull/36 https://github.com/chainguard-dev/kaniko/pull/39 https://github.com/chainguard-dev/kaniko/pull/62, forcing us to write dockerfiles in a way that assert file-modes (see https://github.com/chainguard-dev/kaniko/pull/39/files).

With this change we switch our integration tests to use [diffoci](https://github.com/reproducible-containers/diffoci/) instead which can do far more elaborate checks, as it works on the tar record itself and therefore can compare all meta-data too. As our implementation still has a lot of gaps to docker we need to add a lot of ignores, ignores that should normally not be necessary, hence they are currently still kept in a fork https://github.com/mzihlmann/diffoci, but that is actually a good thing as at least we now know where we have implementation gaps and can start working them off.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
