### PR TITLE
skip-unused-stages fails on numeric references

### DIFF
--- a/integration/images.go
+++ b/integration/images.go
@@ -80,13 +80,14 @@ var additionalDockerFlagsMap = map[string][]string{
 
 // Arguments to build Dockerfiles with when building with kaniko
 var additionalKanikoFlagsMap = map[string][]string{
-	"Dockerfile_test_add":                    {"--single-snapshot"},
-	"Dockerfile_test_run_new":                {"--use-new-run=true"},
-	"Dockerfile_test_run_redo":               {"--snapshot-mode=redo"},
-	"Dockerfile_test_scratch":                {"--single-snapshot"},
-	"Dockerfile_test_maintainer":             {"--single-snapshot"},
-	"Dockerfile_test_target":                 {"--target=second"},
-	"Dockerfile_test_snapshotter_ignorelist": {"--use-new-run=true", "-v=trace"},
+	"Dockerfile_test_add":                         {"--single-snapshot"},
+	"Dockerfile_test_run_new":                     {"--use-new-run=true"},
+	"Dockerfile_test_run_redo":                    {"--snapshot-mode=redo"},
+	"Dockerfile_test_scratch":                     {"--single-snapshot"},
+	"Dockerfile_test_maintainer":                  {"--single-snapshot"},
+	"Dockerfile_test_target":                      {"--target=second"},
+	"Dockerfile_test_snapshotter_ignorelist":      {"--use-new-run=true", "-v=trace"},
+	"Dockerfile_test_copy_chown_nonexisting_user": {"--skip-unused-stages"},
 }
 
 // output check to do when building with kaniko

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -349,50 +349,53 @@ func unifyArgs(metaArgs []instructions.ArgCommand, buildArgs []string) []string 
 
 // skipUnusedStages returns the list of used stages without the unnecessaries ones
 func skipUnusedStages(stages []instructions.Stage, lastStageIndex *int, target string) []instructions.Stage {
-	stagesDependencies := make(map[string]bool)
-	var onlyUsedStages []instructions.Stage
-	idx := *lastStageIndex
+	stageByName := make(map[string]int)
 
-	lastStageBaseName := stages[idx].BaseName
+	for idx, s := range stages {
+		if s.Name != "" {
+			stageByName[s.Name] = idx
+		}
+	}
 
-	for i := idx; i >= 0; i-- {
+	stagesDependencies := make([]bool, len(stages))
+	stagesDependencies[*lastStageIndex] = true
+
+	for i := *lastStageIndex; i >= 0; i-- {
+		if !stagesDependencies[i] {
+			continue
+		}
 		s := stages[i]
-		if (s.Name != "" && stagesDependencies[s.Name]) || s.Name == lastStageBaseName || i == idx {
-			for _, c := range s.Commands {
-				switch cmd := c.(type) {
-				case *instructions.CopyCommand:
-					stageName := cmd.From
-					if copyFromIndex, err := strconv.Atoi(stageName); err == nil {
-						stageName = stages[copyFromIndex].Name
-					}
-					if !stagesDependencies[stageName] {
-						stagesDependencies[stageName] = true
+		if BaseIndex, ok := stageByName[s.BaseName]; ok {
+			// There can be references that appear as non-existing stages
+			// ie. `FROM debian AS base` would try refer to `debian` as stage
+			// before falling back to `debian` as a docker image.
+			stagesDependencies[BaseIndex] = true
+		}
+		for _, c := range s.Commands {
+			switch cmd := c.(type) {
+			case *instructions.CopyCommand:
+				if copyFromIndex, err := strconv.Atoi(cmd.From); err == nil {
+					// numeric reference `COPY --from=0`
+					stagesDependencies[copyFromIndex] = true
+				} else {
+					// named reference `COPY --from=base`
+					if copyFromIndex, ok := stageByName[cmd.From]; ok {
+						// There can be references that appear as non-existing stages
+						// ie. `COPY --from=debian` would try refer to `debian` as stage
+						// before falling back to `debian` as a docker image.
+						stagesDependencies[copyFromIndex] = true
 					}
 				}
 			}
-			if i != idx {
-				stagesDependencies[s.BaseName] = true
-			}
 		}
-	}
-	dependenciesLen := len(stagesDependencies)
-	if target == "" && dependenciesLen == 0 {
-		return stages
-	} else if dependenciesLen > 0 {
-		for i := 0; i < idx; i++ {
-			if stages[i].Name == "" {
-				continue
-			}
-			s := stages[i]
-			if stagesDependencies[s.Name] || s.Name == lastStageBaseName {
-				onlyUsedStages = append(onlyUsedStages, s)
-			}
-		}
-	}
-	onlyUsedStages = append(onlyUsedStages, stages[idx])
-	if idx > len(onlyUsedStages)-1 {
-		*lastStageIndex = len(onlyUsedStages) - 1
 	}
 
+	var onlyUsedStages []instructions.Stage
+	for i := 0; i < *lastStageIndex+1; i++ {
+		if stagesDependencies[i] {
+			onlyUsedStages = append(onlyUsedStages, stages[i])
+		}
+	}
+	*lastStageIndex = len(onlyUsedStages) - 1
 	return onlyUsedStages
 }

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -390,6 +390,21 @@ func skipUnusedStages(stages []instructions.Stage, lastStageIndex *int, target s
 		}
 	}
 
+	// When we don't pass any target kaniko implicitly builds all stages.
+	// This is not only sub-optimal, but also different to docker.
+	// I removed this in https://github.com/mzihlmann/kaniko/pull/27 already
+	// on my end. But to keep the behaviour consistent on your end, this here implements the same logic.
+	// Just drop it if you want to optimize the builds in the same way as I do.
+	dependenciesLen := 0
+	for _, s := range stagesDependencies {
+		if s {
+			dependenciesLen += 1
+		}
+	}
+	if target == "" && dependenciesLen < 2 {
+		return stages
+	}
+
 	var onlyUsedStages []instructions.Stage
 	for i := 0; i < *lastStageIndex+1; i++ {
 		if stagesDependencies[i] {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/mzihlmann/kaniko/issues/102

**Description**

Honestly I was not even aware that this is legal dockerfile syntax, but in `COPY` you can refer to stages by their index.

```Dockerfile
FROM debian
FROM scratch
COPY --from=0 ...
```

This `0` refers to the `debian` stage. The same syntax is not legal for `FROM`, hence a bit surprising. 
Anyways, our stage optimization logic relies on the stage-names to count which stages are in use and which aren't. This of course breaks in the example above, as the `FROM debian` stage has no name, yet still gets referenced. To fix this we can simply switch the counting logic to use indexes instead of names, as indexes work in either case.

On your end there is an additional caveat, as you do not yet implement https://github.com/mzihlmann/kaniko/pull/27
This means that if no target was specified you still want to build all stages (which is unlike docker). I can open a second PR to drop that behaviour or we can drop it here implicitly by removing the last commit (that reintroduces that behaviour for you).


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
