### PR TITLE
Persist capabilities

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_cg73
+++ b/integration/dockerfiles/Dockerfile_test_issue_cg73
@@ -1,0 +1,18 @@
+FROM debian AS base
+RUN apt-get update \
+    && apt-get install -y \
+        libcap2-bin \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN touch /blubb
+RUN setcap "cap_net_raw+ep" /blubb
+
+FROM debian
+
+RUN apt-get update \
+    && apt-get install -y \
+        libcap2-bin \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=base /blubb /
+RUN getcap /blubb

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -41,6 +41,7 @@ import (
 	otiai10Cpy "github.com/otiai10/copy"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -760,7 +761,13 @@ func CopyFile(src, dest string, context FileContext, uid, gid int64, chmod fs.Fi
 	if useDefaultChmod {
 		mode = fi.Mode()
 	}
-	return false, CreateFile(dest, srcFile, mode, uint32(uid), uint32(gid))
+
+	err = CreateFile(dest, srcFile, mode, uint32(uid), uint32(gid))
+	if err != nil {
+		return false, err
+	}
+
+	return false, CopyCapabilities(src, dest)
 }
 
 func NewFileContextFromDockerfile(dockerfilePath, buildcontext string) (FileContext, error) {
@@ -985,7 +992,8 @@ func CopyFileOrSymlink(src string, destDir string, root string) error {
 	if err := os.Chmod(destFile, fi.Mode()); err != nil {
 		return errors.Wrap(err, "copying file mode")
 	}
-	return nil
+
+	return CopyCapabilities(src, destFile)
 }
 
 // CopyOwnership copies the file or directory ownership recursively at src to dest
@@ -1033,6 +1041,24 @@ func CopyOwnership(src string, destDir string, root string) error {
 		stat := info.Sys().(*syscall.Stat_t)
 		return os.Chown(destPath, int(stat.Uid), int(stat.Gid))
 	})
+}
+
+// CopyCapabilities copies the file capabilites from src to dest
+func CopyCapabilities(src string, dest string) error {
+	capBuf := make([]byte, 1024)
+	n, err := unix.Getxattr(src, "security.capability", capBuf)
+	if err == syscall.ENODATA {
+		return nil
+	} else if err != nil {
+		return errors.Wrap(err, "getting security.capability from src")
+	}
+	if n > 0 {
+		err = unix.Setxattr(dest, "security.capability", capBuf[:n], 0)
+		if err != nil {
+			return errors.Wrap(err, "setting security.capability on dest")
+		}
+	}
+	return nil
 }
 
 func createParentDirectory(path string, uid int, gid int) error {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #73 

Cherry-Picked from https://github.com/mzihlmann/kaniko/pull/107

**Description**
So far our implementation only looked at file-mode, permissions and timestamps, but there is more to meta-data. capabilities are one of them as shown in the above issue. We actually lose them in two places, when we COPY files over and when we temporarily store them between stages. Surprisingly they are handled graciously in cache already, although I have not yet checked where exactly.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
