### PR TITLE
COPY with restrictive chmod makes directory inacessible

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_3166
+++ b/integration/dockerfiles/Dockerfile_test_issue_3166
@@ -1,0 +1,10 @@
+FROM debian
+
+USER nobody
+
+# Fails on main@1d2bff5 before #3166:
+# When we COPY --chmod a folder, the chmod is not only
+# applied to the contents of the copy, but all implicitly created
+# directories too, including the top-level directory.
+COPY --chmod=400 context/ /some/nested/context
+RUN ls -la /some/nested/context

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -679,7 +679,14 @@ func CopyDir(src, dest string, context FileContext, uid, gid int64, chmod fs.Fil
 			return nil, errors.Wrap(err, "copying dir")
 		}
 		destPath := filepath.Join(dest, file)
-		if fi.IsDir() {
+		if file == "." {
+			logrus.Tracef("Creating directory %s", destPath)
+
+			uid, gid := DetermineTargetFileOwnership(fi, uid, gid)
+			if err := MkdirAllWithPermissions(destPath, 0755, uid, gid); err != nil {
+				return nil, err
+			}
+		} else if fi.IsDir() {
 			logrus.Tracef("Creating directory %s", destPath)
 
 			mode := chmod


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/GoogleContainerTools/kaniko/issues/3166

**Description**

When COPY --chmod is used to create an implicit filetree, the chmod is not only applied to the copied contents, but to all implicitly created parent dirs too. This causes issues when files are copied with file-specific permissions (ie r--) as then the parent directories become inaccessible due to the missing execute bit.

The solution is to introduce special handling for the top-level directory when we COPY. The top-level directory of the COPY command implicitly creates all parent directories too. chmod override should not be used when creating this directory, instead a regular 0755 mode should be set. This is in-line with what buildkit does.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
