### PR TITLE
group dependabot updates for go and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,20 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      gomod:
+        update-types:
+          - "patch"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    groups:
+      actions:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: docker
     directory: /deploy


### PR DESCRIPTION
will help for dependencies that come together in several PRs like the was deps and reduce the manual work to rebase and also reduce the ci burn

