### PR TITLE
Add support Dockerfile heredocs in RUN instruction

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_1713
+++ b/integration/dockerfiles/Dockerfile_test_issue_1713
@@ -8,15 +8,21 @@ RUN echo 'hello 1 from inline'; \
 
 # run w/ heredoc
 RUN <<EOT
-
 apk add --no-cache curl jq skopeo python3
+
 cat > result.txt << EOFF
-echo 'Hello 1 from heredoc'
-echo 'Hello 2 from heredoc'
+Hello 1 from result.txt using heredoc
+Hello 2 from result.txt using heredoc
 EOFF
+
 EOT
 
 RUN cat result.txt
+
+RUN <<EOT
+echo 'Hello 1 from heredoc'
+echo 'Hello 2 from heredoc'
+EOT
 
 RUN <<"EOF"
 python3 <<EOT
@@ -27,5 +33,11 @@ else:
     print("a is not 2")
 EOT
 EOF
+
+RUN cat <<file1.txt > /tmp/file1.txt && cat <<file2.txt > /tmp/file2.txt
+Hello from file1
+file1.txt
+Hello from file2
+file2.txt
 
 ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
Addresses support of https://github.com/GoogleContainerTools/kaniko/issues/1713

**Description**

We found some Dockerfiles are utilizing heredoc in RUN instructions, for example from the issue mentioned.
```
# syntax=docker/dockerfile:1-3-labs
FROM bitnami/php-fpm:latest

EXPOSE 9000
WORKDIR /app

RUN <<EOF
apt-get update -y
apt-get install -y php-mbstring php-mysqli
EOF
```

This PR enables of appending of heredoc content to the RUN command execution. Result of the [implementation](https://github.com/anandadfoxx/kaniko/commit/0b31b96cd59b5c3e3fb605ffd56a021684577a9f#diff-ea835ba5eff883f863af2b9a490f5ccebd8ce3618c8d6d73f5ca15712e4f1e49) is shown below.
<img width="796" height="381" alt="image" src="https://github.com/user-attachments/assets/3d008750-72a8-4d8f-8b29-57b5ab45a658" />

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- add support for Dockerfile heredoc syntax in RUN instructions
```
