### PR TITLE
Cupdate ci and drop integration test

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -67,6 +67,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       # Don't build for all platforms on PRs.
       - id: platforms

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
 
       - run: make test

--- a/integration/dockerfiles/Dockerfile_test_issue_684
+++ b/integration/dockerfiles/Dockerfile_test_issue_684
@@ -1,4 +1,0 @@
-# ubuntu:bionic-20200219
-FROM ubuntu@sha256:04d48df82c938587820d7b6006f5071dbbffceb7ca01d2814f81857c631d44df as builder
-
-RUN apt-get update && apt-get -y upgrade && apt-get -y install lib32stdc++6 wget


### PR DESCRIPTION
doing similar that was did https://github.com/mzihlmann/kaniko/pull/198

tests for that is failing

```
  5 packages can be upgraded. Run 'apt list --upgradable' to see them.
            W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/focal-security/InRelease  Could not connect to security.ubuntu.com:80 (185.125.190.36), connection timed out [IP: 185.125.190.36 80]
            W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/focal-backports/universe/binary-amd64/Packages  Could not connect to archive.ubuntu.com:80 (185.125.190.39), connection timed out [IP: 185.125.190.39 80]
            W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/focal-backports/main/binary-amd64/Packages  Unable to connect to archive.ubuntu.com:http: [IP: 185.125.190.39 80]
            W: Some index files failed to download. They have been ignored, or old ones used instead.
             ---> Removed intermediate container 2a1b6128f667
             ---> dafb6ae545f7
            Step 3/8 : RUN apt install -y libbsd0
             ---> Running in 963a182071ee
            
            WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
            
            Reading package lists...
            Building dependency tree...
            Reading state information...
            The following NEW packages will be installed:
              libbsd0
            0 upgraded, 1 newly installed, 0 to remove and 5 not upgraded.
            Need to get 45.4 kB of archives.
            After this operation, 204 kB of additional disk space will be used.
            Err:1 http://archive.ubuntu.com/ubuntu focal/main amd64 libbsd0 amd64 0.10.0-1
              Could not connect to archive.ubuntu.com:80 (91.189.91.82), connection timed out [IP: 91.189.91.82 80]
            E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/libb/libbsd/libbsd0_0.10.0-1_amd64.deb  Could not connect to archive.ubuntu.com:80 (91.189.91.82), connection timed out [IP: 91.189.91.82 80]
            E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

maybe is deprecated and not serving that anymore