### PR TITLE
fix(util): store symlink targets verbatim during tar extraction

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -432,16 +432,18 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 
 	case tar.TypeSymlink:
 		logrus.Tracef("Symlink from %s to %s", hdr.Linkname, path)
-		// Resolve the symlink target relative to the entry's parent directory
-		// to get the effective path from the extraction root, then verify it
-		// stays within the destination.
-		effectivePath := filepath.Clean(filepath.Join(filepath.Dir(cleanedName), hdr.Linkname))
-		if filepath.IsAbs(hdr.Linkname) {
-			effectivePath = filepath.Clean(hdr.Linkname)
-		}
-		if effectivePath == ".." || strings.HasPrefix(effectivePath, "../") {
-			return fmt.Errorf("symlink target %q resolves outside destination", hdr.Linkname)
-		}
+		// Do not validate or rewrite the symlink target. Extracting a symlink
+		// only writes the target *string* to disk at "path", which is already
+		// confined to dest by the SecureJoin on the parent directory above —
+		// creating the link never traverses anywhere itself. A target that
+		// lexically escapes the root is not a traversal risk: excess ".."
+		// components are clamped at the root when the link is followed, and any
+		// later tar entry that writes *through* this symlink is independently
+		// confined by SecureJoin on its own parent directory. Rejecting targets
+		// here (added with the GHSA-6rxq-q92g-4rmf fix) broke legitimate base
+		// images whose symlinks use more ".." than their depth, e.g.
+		// amazoncorretto's
+		// cacerts -> ../../../../../../../../../../etc/pki/java/cacerts.
 		// The base directory for a symlink may not exist before it is created.
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return err

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -322,13 +322,17 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 	// creating self-referential symlink loops (e.g. dash -> dash).
 	secureDir, err := securejoin.SecureJoin(dest, filepath.Dir(cleanedName))
 	if err != nil {
-		// During layer extraction, symlink chains may be incomplete,
-		// causing ELOOP. Fall back to the lexical path — the OS will
-		// encounter the same resolution failure if the path is used.
 		if !errors.Is(err, syscall.ELOOP) {
 			return fmt.Errorf("resolving path for %q: %w", hdr.Name, err)
 		}
-		secureDir = filepath.Join(dest, filepath.Dir(cleanedName))
+		// The parent path contains a symlink loop, so it cannot be securely
+		// resolved. Skip the entry rather than falling back to an unresolved
+		// lexical path: the OS could dereference an escaping symlink in that
+		// path and write outside dest (PSEC-1492). Skipping (vs erroring) mirrors
+		// the ignore-list skip below and keeps one pathological entry from
+		// aborting the whole image build, while staying fail-closed.
+		logrus.Warnf("Skipping %q: parent path cannot be securely resolved (symlink loop)", hdr.Name)
+		return nil
 	}
 	path := filepath.Join(secureDir, filepath.Base(cleanedName))
 	base := filepath.Base(path)
@@ -462,8 +466,9 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		//     TypeSymlink branches delete the existing entry first, and the
 		//     TypeDir branch removes a pre-existing symlink before MkdirAll, so
 		//     the write never follows it outside dest.
-		// This does NOT hold on the ELOOP fallback above, which joins the parent
-		// lexically without resolving symlinks; see that branch.
+		// When a later entry's parent cannot be securely resolved (a symlink
+		// loop, ELOOP above), that entry is skipped rather than written through
+		// an unresolved lexical path, so it is never written outside dest.
 		// The base directory for a symlink may not exist before it is created.
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return err

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -353,7 +353,7 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		// It's possible a file is in the tar before its directory,
 		// or a file was copied over a directory prior to now
 		fi, err := os.Stat(dir)
-		if os.IsNotExist(err) || !fi.IsDir() {
+		if err != nil || !fi.IsDir() {
 			logrus.Debugf("Base %s for file %s does not exist. Creating.", base, path)
 
 			if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -393,6 +393,18 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		currFile.Close()
 	case tar.TypeDir:
 		logrus.Tracef("Creating dir %s", path)
+		// If a symlink already exists at this exact path (e.g. an earlier
+		// escaping symlink entry of the same name), remove it before creating
+		// the directory. MkdirAllWithPermissions stats the path and would
+		// otherwise follow the symlink and chown/chmod its target outside dest
+		// (PSEC-1492). Mirror the delete-before-write the other branches do, but
+		// only for a symlink: a pre-existing real directory is left intact so
+		// its already-extracted contents are preserved.
+		if fi, lerr := os.Lstat(path); lerr == nil && fi.Mode()&os.ModeSymlink != 0 {
+			if err := os.Remove(path); err != nil {
+				return errors.Wrapf(err, "error removing symlink %s to make way for new directory", path)
+			}
+		}
 		if err := MkdirAllWithPermissions(path, mode, int64(uid), int64(gid)); err != nil {
 			return err
 		}
@@ -435,15 +447,23 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		// Do not validate or rewrite the symlink target. Extracting a symlink
 		// only writes the target *string* to disk at "path", which is already
 		// confined to dest by the SecureJoin on the parent directory above —
-		// creating the link never traverses anywhere itself. A target that
-		// lexically escapes the root is not a traversal risk: excess ".."
-		// components are clamped at the root when the link is followed, and any
-		// later tar entry that writes *through* this symlink is independently
-		// confined by SecureJoin on its own parent directory. Rejecting targets
+		// creating the link never traverses anywhere itself. Rejecting targets
 		// here (added with the GHSA-6rxq-q92g-4rmf fix) broke legitimate base
 		// images whose symlinks use more ".." than their depth, e.g.
 		// amazoncorretto's
 		// cacerts -> ../../../../../../../../../../etc/pki/java/cacerts.
+		//
+		// Containment of an escaping symlink is enforced at WRITE time, not by
+		// checking the target string:
+		//   - When a later entry has this symlink as a *parent* component,
+		//     SecureJoin on that entry's parent resolves and clamps it within
+		//     dest (see above).
+		//   - When a later entry reuses this exact name, the TypeReg/TypeLink/
+		//     TypeSymlink branches delete the existing entry first, and the
+		//     TypeDir branch removes a pre-existing symlink before MkdirAll, so
+		//     the write never follows it outside dest.
+		// This does NOT hold on the ELOOP fallback above, which joins the parent
+		// lexically without resolving symlinks; see that branch.
 		// The base directory for a symlink may not exist before it is created.
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return err

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -926,15 +926,83 @@ func TestExtractFile_PathTraversal(t *testing.T) {
 		}
 	})
 
-	t.Run("symlink target outside dest via relative path", func(t *testing.T) {
+	t.Run("symlink with relative escaping target is created but write-through is confined", func(t *testing.T) {
+		// A symlink whose target lexically escapes dest must still be created
+		// verbatim (this is how real base images ship, e.g. amazoncorretto's
+		// cacerts -> ../../../../../../../../../../etc/pki/java/cacerts). The
+		// traversal protection is enforced when a later entry writes *through*
+		// the symlink, not by rejecting the link target.
 		dest := t.TempDir()
 		hdr := linkHeader("./link", "../outside")
-		err := ExtractFile(dest, hdr, filepath.Clean(hdr.Name), bytes.NewReader(nil))
-		if err == nil {
-			t.Fatal("expected error for symlink target outside dest, got nil")
+		if err := ExtractFile(dest, hdr, filepath.Clean(hdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatalf("symlink with relative escaping target should be created, not rejected: %v", err)
 		}
-		if !strings.Contains(err.Error(), "resolves outside destination") {
-			t.Fatalf("unexpected error: %v", err)
+		target, err := os.Readlink(filepath.Join(dest, "link"))
+		if err != nil {
+			t.Fatalf("symlink was not created: %v", err)
+		}
+		if target != "../outside" {
+			t.Fatalf("symlink target = %q, want %q (stored verbatim)", target, "../outside")
+		}
+
+		// Writing through the symlink must stay inside dest.
+		writeHdr := fileHeader("./link/written.txt", "data", 0o644, defaultTestTime)
+		_ = ExtractFile(dest, writeHdr, filepath.Clean(writeHdr.Name), bytes.NewReader([]byte("data")))
+		if _, statErr := os.Stat(filepath.Join(filepath.Dir(dest), "outside", "written.txt")); statErr == nil {
+			t.Fatal("file was written outside dest through symlink")
+		}
+	})
+
+	t.Run("regular file overwriting a pre-existing escaping symlink is contained", func(t *testing.T) {
+		// A tar can ship an (absolute or relative) escaping symlink and then a
+		// regular file at the SAME name. The write must NOT follow the symlink
+		// to its target: FilepathExists uses Lstat and the entry is removed
+		// before os.Create, so a fresh regular file is written inside dest.
+		outsideDir := t.TempDir() // sibling of dest, must stay untouched
+		escaped := filepath.Join(outsideDir, "pwned")
+		dest := t.TempDir()
+
+		// 1) create the escaping symlink: ./evil -> <outsideDir>/pwned
+		linkHdr := linkHeader("./evil", escaped)
+		if err := ExtractFile(dest, linkHdr, filepath.Clean(linkHdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatalf("symlink creation should succeed: %v", err)
+		}
+		// 2) write a regular file at the same name with attacker content
+		fileHdr := fileHeader("./evil", "attacker", 0o644, defaultTestTime)
+		if err := ExtractFile(dest, fileHdr, filepath.Clean(fileHdr.Name), bytes.NewReader([]byte("attacker"))); err != nil {
+			t.Fatalf("overwriting symlink with file should succeed: %v", err)
+		}
+		// The attacker content must NOT have been written to the symlink target.
+		if _, statErr := os.Stat(escaped); statErr == nil {
+			t.Fatalf("write followed the symlink and escaped to %s", escaped)
+		}
+		// dest/evil must now be a regular file, not a symlink.
+		fi, err := os.Lstat(filepath.Join(dest, "evil"))
+		if err != nil {
+			t.Fatalf("lstat dest/evil: %v", err)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			t.Fatal("dest/evil is still a symlink; should be a regular file")
+		}
+	})
+
+	t.Run("symlink with excess-dotdot target (amazoncorretto cacerts) is allowed", func(t *testing.T) {
+		// Regression test for the #326/#330 symlink target check: a symlink
+		// deep in the tree whose target has more ".." than its depth resolves
+		// to the root at follow time and must not be rejected.
+		dest := t.TempDir()
+		name := "usr/lib/jvm/java-21-amazon-corretto/lib/security/cacerts"
+		target := "../../../../../../../../../../etc/pki/java/cacerts"
+		hdr := linkHeader(name, target)
+		if err := ExtractFile(dest, hdr, filepath.Clean(hdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatalf("excess-dotdot symlink should be allowed: %v", err)
+		}
+		got, err := os.Readlink(filepath.Join(dest, name))
+		if err != nil {
+			t.Fatalf("symlink was not created: %v", err)
+		}
+		if got != target {
+			t.Fatalf("symlink target = %q, want %q (stored verbatim)", got, target)
 		}
 	})
 
@@ -1119,13 +1187,24 @@ func TestUnTar_PathTraversal(t *testing.T) {
 		}
 	})
 
-	t.Run("symlink with dotdot target is rejected", func(t *testing.T) {
+	t.Run("symlink with dotdot target is created verbatim", func(t *testing.T) {
+		// A symlink whose target uses ".." must be stored verbatim, matching
+		// upstream kaniko and real container runtimes. Creating the link never
+		// follows the target; traversal is prevented when writing *through* a
+		// symlink (covered by "file through symlink is confined" below).
 		buf := makeTar(t, tar.Header{
 			Name: "ext-link", Typeflag: tar.TypeSymlink, Linkname: "../../etc/passwd",
 		})
 		dest := t.TempDir()
-		if _, err := UnTar(buf, dest); err == nil {
-			t.Fatal("expected error for symlink with dotdot target, got nil")
+		if _, err := UnTar(buf, dest); err != nil {
+			t.Fatalf("symlink with dotdot target should be created, not rejected: %v", err)
+		}
+		target, err := os.Readlink(filepath.Join(dest, "ext-link"))
+		if err != nil {
+			t.Fatalf("symlink was not created: %v", err)
+		}
+		if target != "../../etc/passwd" {
+			t.Fatalf("symlink target = %q, want %q (stored verbatim)", target, "../../etc/passwd")
 		}
 	})
 
@@ -1166,6 +1245,30 @@ func TestUnTar_PathTraversal(t *testing.T) {
 
 		if _, err := os.Stat(filepath.Join(outsideDir, "written.txt")); err == nil {
 			t.Fatal("file was written outside dest through symlink")
+		}
+	})
+
+	t.Run("write through deep relative escaping symlink is confined", func(t *testing.T) {
+		// The strongest version of the attack the removed lexical target check
+		// nominally guarded against: a deep relative symlink that escapes the
+		// root, followed by a write through it. The symlink is now created
+		// verbatim, but SecureJoin on the parent of the second entry clamps the
+		// ".." at the destination root, so the write stays inside dest.
+		outsideDir := t.TempDir() // sibling of dest, must remain untouched
+		marker := filepath.Join(outsideDir, "pwned.txt")
+		dest := t.TempDir()
+		buf := makeTar(t,
+			tar.Header{
+				Name: "evil", Typeflag: tar.TypeSymlink, Linkname: "../../../../../../../../../.." + outsideDir,
+			},
+			tar.Header{
+				Name: "evil/pwned.txt", Size: 5, Mode: 0o644, Typeflag: tar.TypeReg,
+				Uid: os.Getuid(), Gid: os.Getgid(),
+			},
+		)
+		UnTar(buf, dest)
+		if _, err := os.Stat(marker); err == nil {
+			t.Fatalf("file escaped to %s through deep relative symlink", marker)
 		}
 	})
 

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -1045,6 +1045,29 @@ func TestExtractFile_PathTraversal(t *testing.T) {
 		}
 	})
 
+	t.Run("entry whose parent is a symlink loop is skipped", func(t *testing.T) {
+		// SecureJoin returns ELOOP for a parent path containing a symlink loop.
+		// The entry must be skipped (returns nil, writes nothing) rather than
+		// written through an unresolved lexical path (PSEC-1492 ELOOP fallback).
+		dest := t.TempDir()
+		// Build a loop inside dest: a -> b, b -> a.
+		if err := ExtractFile(dest, linkHeader("./a", "b"), "a", bytes.NewReader(nil)); err != nil {
+			t.Fatalf("creating symlink a: %v", err)
+		}
+		if err := ExtractFile(dest, linkHeader("./b", "a"), "b", bytes.NewReader(nil)); err != nil {
+			t.Fatalf("creating symlink b: %v", err)
+		}
+		// An entry under the looping path must be skipped without error.
+		hdr := fileHeader("./a/foo.txt", "data", 0o644, defaultTestTime)
+		if err := ExtractFile(dest, hdr, filepath.Clean(hdr.Name), bytes.NewReader([]byte("data"))); err != nil {
+			t.Fatalf("entry under symlink loop should be skipped (nil), got: %v", err)
+		}
+		// Nothing should have been written under the looping parent.
+		if _, err := os.Lstat(filepath.Join(dest, "a", "foo.txt")); err == nil {
+			t.Fatal("file was written under a symlink-loop parent")
+		}
+	})
+
 	t.Run("symlink with excess-dotdot target (amazoncorretto cacerts) is allowed", func(t *testing.T) {
 		// Regression test for the #326/#330 symlink target check: a symlink
 		// deep in the tree whose target has more ".." than its depth resolves

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -945,11 +945,18 @@ func TestExtractFile_PathTraversal(t *testing.T) {
 			t.Fatalf("symlink target = %q, want %q (stored verbatim)", target, "../outside")
 		}
 
-		// Writing through the symlink must stay inside dest.
+		// Writing through the symlink must stay inside dest. SecureJoin on the
+		// parent resolves "link" and clamps it within dest, so the file lands at
+		// dest/outside/written.txt, never at the sibling ../outside.
 		writeHdr := fileHeader("./link/written.txt", "data", 0o644, defaultTestTime)
-		_ = ExtractFile(dest, writeHdr, filepath.Clean(writeHdr.Name), bytes.NewReader([]byte("data")))
+		if err := ExtractFile(dest, writeHdr, filepath.Clean(writeHdr.Name), bytes.NewReader([]byte("data"))); err != nil {
+			t.Fatalf("write through symlink should succeed (confined), got: %v", err)
+		}
 		if _, statErr := os.Stat(filepath.Join(filepath.Dir(dest), "outside", "written.txt")); statErr == nil {
 			t.Fatal("file was written outside dest through symlink")
+		}
+		if _, statErr := os.Stat(filepath.Join(dest, "outside", "written.txt")); statErr != nil {
+			t.Fatalf("write was not confined to dest/outside as expected: %v", statErr)
 		}
 	})
 
@@ -972,17 +979,69 @@ func TestExtractFile_PathTraversal(t *testing.T) {
 		if err := ExtractFile(dest, fileHdr, filepath.Clean(fileHdr.Name), bytes.NewReader([]byte("attacker"))); err != nil {
 			t.Fatalf("overwriting symlink with file should succeed: %v", err)
 		}
-		// The attacker content must NOT have been written to the symlink target.
-		if _, statErr := os.Stat(escaped); statErr == nil {
-			t.Fatalf("write followed the symlink and escaped to %s", escaped)
-		}
-		// dest/evil must now be a regular file, not a symlink.
+		// dest/evil must now be a regular file (the symlink was Lstat-removed
+		// before os.Create), not a symlink, and must hold the written content.
 		fi, err := os.Lstat(filepath.Join(dest, "evil"))
 		if err != nil {
 			t.Fatalf("lstat dest/evil: %v", err)
 		}
 		if fi.Mode()&os.ModeSymlink != 0 {
 			t.Fatal("dest/evil is still a symlink; should be a regular file")
+		}
+		got, err := os.ReadFile(filepath.Join(dest, "evil"))
+		if err != nil {
+			t.Fatalf("reading dest/evil: %v", err)
+		}
+		if string(got) != "attacker" {
+			t.Fatalf("dest/evil content = %q, want %q (write not confined in-dest)", got, "attacker")
+		}
+		// And nothing was created at the symlink target outside dest.
+		if _, statErr := os.Stat(escaped); statErr == nil {
+			t.Fatalf("write followed the symlink and escaped to %s", escaped)
+		}
+	})
+
+	t.Run("TypeDir must not chmod a directory outside dest via a pre-existing symlink", func(t *testing.T) {
+		// PSEC-1492 High: an escaping symlink (now stored verbatim) followed by
+		// a same-name directory entry must not let MkdirAllWithPermissions
+		// follow the symlink and chmod/chown the external target. The symlink is
+		// removed before the directory is created. Fails before the TypeDir fix.
+		outsideDir := t.TempDir()
+		victim := filepath.Join(outsideDir, "victim")
+		if err := os.Mkdir(victim, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		dest := t.TempDir()
+
+		// 1) escaping symlink ./evil -> <outsideDir>/victim
+		linkHdr := linkHeader("./evil", victim)
+		if err := ExtractFile(dest, linkHdr, filepath.Clean(linkHdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatalf("symlink creation should succeed: %v", err)
+		}
+		// 2) same-name directory entry with an attacker-controlled mode
+		dHdr := dirHeader("./evil", 0o777)
+		if err := ExtractFile(dest, dHdr, filepath.Clean(dHdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatalf("dir creation should succeed: %v", err)
+		}
+
+		// The external victim's mode must be unchanged (not chmod'd to 0777).
+		vi, err := os.Lstat(victim)
+		if err != nil {
+			t.Fatalf("lstat victim: %v", err)
+		}
+		if vi.Mode().Perm() != 0o700 {
+			t.Fatalf("external dir mode changed to %o; chmod escaped through the symlink", vi.Mode().Perm())
+		}
+		// dest/evil must now be a real directory, not the symlink.
+		di, err := os.Lstat(filepath.Join(dest, "evil"))
+		if err != nil {
+			t.Fatalf("lstat dest/evil: %v", err)
+		}
+		if di.Mode()&os.ModeSymlink != 0 {
+			t.Fatal("dest/evil is still a symlink; should be a real directory")
+		}
+		if !di.IsDir() {
+			t.Fatal("dest/evil is not a directory")
 		}
 	})
 
@@ -1239,12 +1298,16 @@ func TestUnTar_PathTraversal(t *testing.T) {
 				Uid: os.Getuid(), Gid: os.Getgid(),
 			},
 		)
-		// Extraction may or may not return an error; either way the file
-		// must not appear outside dest.
-		UnTar(buf, dest)
-
+		if _, err := UnTar(buf, dest); err != nil {
+			t.Fatalf("extraction should succeed (confined), got: %v", err)
+		}
+		// The file must not escape, and must land at the confined in-dest path.
 		if _, err := os.Stat(filepath.Join(outsideDir, "written.txt")); err == nil {
 			t.Fatal("file was written outside dest through symlink")
+		}
+		confined := filepath.Join(dest, outsideDir, "written.txt")
+		if _, err := os.Stat(confined); err != nil {
+			t.Fatalf("write was not confined to dest as expected (%s): %v", confined, err)
 		}
 	})
 
@@ -1266,9 +1329,17 @@ func TestUnTar_PathTraversal(t *testing.T) {
 				Uid: os.Getuid(), Gid: os.Getgid(),
 			},
 		)
-		UnTar(buf, dest)
+		if _, err := UnTar(buf, dest); err != nil {
+			t.Fatalf("extraction should succeed (confined), got: %v", err)
+		}
 		if _, err := os.Stat(marker); err == nil {
 			t.Fatalf("file escaped to %s through deep relative symlink", marker)
+		}
+		// SecureJoin clamps the ".." at the dest root, so the write must land at
+		// the confined in-dest location rather than escaping.
+		confined := filepath.Join(dest, outsideDir, "pwned.txt")
+		if _, err := os.Stat(confined); err != nil {
+			t.Fatalf("write was not confined to dest as expected (%s): %v", confined, err)
 		}
 	})
 


### PR DESCRIPTION
> **Status: DRAFT, not ready to merge.** Posting for review. This needs a thorough review including from the security team before it lands, so it will be a few days. See #326 / #330 thread context.

## Summary

Fixes the regression reported on #330 (and originally introduced by #326) where extracting certain base images fails with:

```
error building image: error building stage: failed to get filesystem from image: symlink target "../../../../../../../../../../etc/pki/java/cacerts" resolves outside destination
```

Reported against `amazoncorretto` (and images built on it, e.g. `sonarsource/sonar-scanner-cli`). The build fails while unpacking the base-image rootfs, before any `RUN` instruction executes. Reverting to v1.25.9 avoids it.

## Root cause

#326 fixed a real path-traversal bug (GHSA-6rxq-q92g-4rmf: tar entry names like `../outside.txt` escaping the extraction root) by switching to `securejoin.SecureJoin`. As part of that change it also added a **lexical check on symlink targets** in the `tar.TypeSymlink` branch of `ExtractFile`:

```go
effectivePath := filepath.Clean(filepath.Join(filepath.Dir(cleanedName), hdr.Linkname))
if filepath.IsAbs(hdr.Linkname) { effectivePath = filepath.Clean(hdr.Linkname) }
if effectivePath == ".." || strings.HasPrefix(effectivePath, "../") {
    return fmt.Errorf("symlink target %q resolves outside destination", hdr.Linkname)
}
```

amazoncorretto ships `usr/lib/jvm/.../lib/security/cacerts -> ../../../../../../../../../../etc/pki/java/cacerts` — a link 6 directories deep whose target uses 10 `../`. Cleaning leaves `../../../../etc/pki/java/cacerts`, which trips the prefix check.

The check is **incorrect and redundant**:

1. Excess `..` components are clamped at the root when a symlink is followed, so this link resolves to `/etc/pki/java/cacerts` inside the container root, exactly as it does under Docker. It is safe at runtime.
2. Creating a symlink only writes the target *string* to disk; it never traverses anything. The actual traversal protection is `SecureJoin` on the **parent directory** of every extracted entry (added in #326, refined in #330), which clamps any write *through* a symlink back inside the destination. Upstream kaniko stores symlink targets verbatim with no such check.

## The fix

Remove the symlink-target lexical check and store the target verbatim (`os.Symlink(hdr.Linkname, path)`), matching upstream kaniko and Docker. The entry-name traversal guard from #326 and the symlink-loop fix from #330 are untouched.

## Scope / compatibility

- Reverts symlink-target handling to pre-#326 / upstream behaviour. No `ExtractFile` signature change, no new dependencies.
- **#326 preserved:** entry-name traversal guards (`cleanedName` check + `SecureJoin`) unchanged.
- **#330 preserved:** the `dash -> dash` symlink-loop fix lives in the path computation, which is unchanged (`TestExtractFile_SymlinkOverwrite` still passes).

## Security posture

GHSA-6rxq-q92g-4rmf is about writing files *outside* the destination. Both vectors remain closed:

1. **Entry name with `../`** → rejected at the `cleanedName` guard + `SecureJoin`.
2. **Writing *through* a symlink** → confined by `SecureJoin` on the parent directory of every entry. This is the real guard and is unchanged.

The removed check only inspected the symlink *target string*; creating a symlink writes a string to an already-confined location and never traverses, so removing it cannot write anything outside the destination. Net posture matches upstream kaniko, which has never had this check.

## Tests

- Updated the two cases that asserted the old (incorrect) rejection — `TestExtractFile_PathTraversal/symlink target outside dest via relative path` and `TestUnTar_PathTraversal/symlink with dotdot target is rejected` — to assert the new verbatim-create behaviour.
- Added regression coverage:
  - amazoncorretto-style excess-`..` symlink is created (the reported bug).
  - **Adversarial:** a deep relative escaping symlink (`evil -> ../../../../../../../../../../<outsideDir>`) followed by a write to `evil/pwned.txt` does **not** escape — `SecureJoin` clamps the `..` at the destination root.
- `go build ./...` clean; `go vet ./pkg/util/` clean; full `pkg/util` suite passes locally.

## Why removing the check is not less secure

Three independent points, in addition to the two-vector analysis above:

1. **The change only newly permits the *safer* form of escaping symlink.** The removed check only blocked *relative* escaping targets (`../../etc`). **Absolute** escaping targets (`/etc/passwd`) were already permitted before this change — `#326`'s own `file through symlink is confined` test ships an absolute out-of-dest target and asserts the symlink *is* created. So "an escaping symlink can exist in the extracted tree" was already true. All this change adds is the relative form, and in production kaniko `dest` is the container root `/`, so a relative `..` symlink is clamped at `/` by the kernel and cannot escape the container root at all. It is a strict subset of, and safer than, what was already reachable.

2. **The real traversal protections are untouched and sit upstream of the removed check.** None of these were modified:
   - Entry names containing `../` → rejected by the `cleanedName` guard.
   - Writing *through* a symlink (the actual GHSA vector) → `SecureJoin` on the parent directory of every entry resolves and clamps symlink components back inside `dest` (proven by the deep-relative-escape adversarial test).
   - A write landing on a pre-existing symlink at the *final* path component (the subtle case, since #330 deliberately does not SecureJoin the final component) → `FilepathExists` uses `Lstat`, so the symlink is detected and `RemoveAll`'d before `os.Create`; the write replaces the link, never follows it (proven by the "regular file overwriting a pre-existing escaping symlink is contained" test).

3. **Matching upstream is itself the safer position.** Upstream kaniko, Docker and BuildKit all store symlink targets verbatim and rely on safe-join at *write* time, not on validating the target string. `#326` diverged from that, and that divergence is exactly what produced this bug. Re-converging reduces the surface for surprises.

## Caveats for the security review

Two things to look at explicitly (neither blocks the change, but both deserve fresh eyes):

- **Load-bearing invariant:** the model now rests entirely on "every entry placement goes through `SecureJoin`-on-parent, and final components are delete-before-write using `Lstat`." This change does not weaken that invariant, but it does remove the redundant belt, so `SecureJoin` is now the sole line. If a future refactor adds a new typeflag handler, or optimises away a `SecureJoin` call, escaping symlinks become exploitable again. The added adversarial tests partially guard this; please treat the invariant as load-bearing.
- **Pre-existing sharp edge in `tar.TypeDir`:** unlike the `TypeReg`/`TypeSymlink`/`TypeLink` branches, the directory branch does not delete a pre-existing symlink before `MkdirAll`. This is **pre-existing** (not introduced here) and is contained in production by root-clamping plus re-clamping of any contents written into the directory, but it is the one place worth a deliberate look.

Net: this does not introduce a new exploitable traversal, and it brings kaniko's behaviour in line with the far-more-scrutinised upstream/Docker/BuildKit model.

## Credit

Pedro Fragola (Chainguard) independently reproduced, diagnosed and produced an equivalent fix (ZD10054); co-authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: addressed PSEC-1492 security review (egibs)

Second commit on this branch responds to the review:

- **High — `TypeDir` symlink-escape (now fixed).** `tar.TypeDir` was the only `ExtractFile` branch that did not delete a pre-existing entry before writing, so an escaping symlink followed by a same-name directory entry let `MkdirAllWithPermissions` (`os.Stat`/`Chown`/`Chmod`) follow the link and chmod/chown a directory **outside** `dest` (reviewer verified `0700 → 0777`). Fixed by `Lstat`+removing a pre-existing *symlink* before `MkdirAllWithPermissions` (mirrors the other three branches; a real directory is left intact). A pin test reproduces the escape and fails without the fix.
- **Medium — comment accuracy.** Narrowed the symlink-case justification comment: confinement holds for parent-component writes and same-name overwrites, and explicitly **not** on the ELOOP lexical fallback.
- **Medium — nil-deref.** Fixed the pre-existing `TypeReg` panic when `os.Stat(dir)` returns a non-`IsNotExist` error (`err != nil || !fi.IsDir()`).
- **Test quality.** Made the write-through tests non-vacuous (assert extraction succeeds and the write lands at the confined in-`dest` path, not merely absent outside).

**Open for reviewer decision — ELOOP lexical fallback.** When `SecureJoin` returns `ELOOP` the parent is joined lexically without resolution, so a later write through an unresolved escaping parent symlink is not confined. Pre-existing; making it fail-closed risks regressing the incomplete-chain handling added in #330, so it is flagged for ProdSec/owner input rather than changed unilaterally.